### PR TITLE
Fix accidental text deletion when running prettify with text selected

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -75,7 +75,7 @@ export default class MarkdownPrettifier extends Plugin {
       const editor = view.sourceMode.cmEditor;
 
       // Remember the cursor
-      const cursor = editor.getCursor();
+      const cursor = Object.assign({}, editor.getCursor());
 
       editor.execCommand("selectAll");
       let text = editor.getSelection();


### PR DESCRIPTION
Looks like the `cursor` was accidentally mutated, and that caused issues with the `replaceSelection()` command.

This addresses the following issue: https://github.com/cristianvasquez/obsidian-prettify/issues/46

Here are the steps I used to reproduce the issue:
1. Create a new note with the following content:
```
# a
a
```
2. Ctrl + A
3. Run the prettifier